### PR TITLE
Reduce memory allocations by reusing pixel buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gift.test

--- a/convolution.go
+++ b/convolution.go
@@ -205,7 +205,6 @@ func (p *convolutionFilter) Draw(dst draw.Image, src image.Image, options *Optio
 //	)
 //	dst := image.NewRGBA(g.Bounds(src.Bounds()))
 //	g.Draw(dst, src)
-//
 func Convolution(kernel []float32, normalize, alpha, abs bool, delta float32) Filter {
 	return &convolutionFilter{
 		kernel:    kernel,
@@ -286,12 +285,13 @@ func convolve1dv(dst draw.Image, src image.Image, kernel []float32, options *Opt
 	pixGetter := newPixelGetter(src)
 	pixSetter := newPixelSetter(dst)
 	parallelize(options.Parallelization, srcb.Min.X, srcb.Max.X, func(start, stop int) {
-		srcBuf := make([]pixel, srcb.Dy())
-		dstBuf := make([]pixel, srcb.Dy())
+		buf := getPixelBuf(srcb.Dy(), srcb.Dy())
+		defer putPixelBuf(buf)
+
 		for x := start; x < stop; x++ {
-			pixGetter.getPixelColumn(x, &srcBuf)
-			convolveLine(dstBuf, srcBuf, weights)
-			pixSetter.setPixelColumn(dstb.Min.X+x-srcb.Min.X, dstBuf)
+			pixGetter.getPixelColumn(x, &buf.src)
+			convolveLine(buf.dst, buf.src, weights)
+			pixSetter.setPixelColumn(dstb.Min.X+x-srcb.Min.X, buf.dst)
 		}
 	})
 }
@@ -311,12 +311,13 @@ func convolve1dh(dst draw.Image, src image.Image, kernel []float32, options *Opt
 	pixGetter := newPixelGetter(src)
 	pixSetter := newPixelSetter(dst)
 	parallelize(options.Parallelization, srcb.Min.Y, srcb.Max.Y, func(start, stop int) {
-		srcBuf := make([]pixel, srcb.Dx())
-		dstBuf := make([]pixel, srcb.Dx())
+		buf := getPixelBuf(srcb.Dx(), srcb.Dx())
+		defer putPixelBuf(buf)
+
 		for y := start; y < stop; y++ {
-			pixGetter.getPixelRow(y, &srcBuf)
-			convolveLine(dstBuf, srcBuf, weights)
-			pixSetter.setPixelRow(dstb.Min.Y+y-srcb.Min.Y, dstBuf)
+			pixGetter.getPixelRow(y, &buf.src)
+			convolveLine(buf.dst, buf.src, weights)
+			pixSetter.setPixelRow(dstb.Min.Y+y-srcb.Min.Y, buf.dst)
 		}
 	})
 }
@@ -384,7 +385,6 @@ func (p *gausssianBlurFilter) Draw(dst draw.Image, src image.Image, options *Opt
 //	)
 //	dst := image.NewRGBA(g.Bounds(src.Bounds()))
 //	g.Draw(dst, src)
-//
 func GaussianBlur(sigma float32) Filter {
 	return &gausssianBlurFilter{
 		sigma: sigma,
@@ -460,7 +460,6 @@ func (p *unsharpMaskFilter) Draw(dst draw.Image, src image.Image, options *Optio
 //	)
 //	dst := image.NewRGBA(g.Bounds(src.Bounds()))
 //	g.Draw(dst, src)
-//
 func UnsharpMask(sigma, amount, threshold float32) Filter {
 	return &unsharpMaskFilter{
 		sigma:     sigma,
@@ -567,7 +566,6 @@ func (p *hvConvolutionFilter) Draw(dst draw.Image, src image.Image, options *Opt
 			}
 		}
 	})
-
 }
 
 // Sobel creates a filter that applies a sobel operator to an image.

--- a/gift_test.go
+++ b/gift_test.go
@@ -381,7 +381,6 @@ func TestDrawAt(t *testing.T) {
 			t.Errorf("test [%s] failed: %#v, %#v", d.desc, dst.Bounds(), dst.Pix)
 		}
 	}
-
 }
 
 type fakeDrawImage struct {
@@ -448,7 +447,6 @@ func TestSubImage(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func TestDraw(t *testing.T) {

--- a/resize.go
+++ b/resize.go
@@ -147,12 +147,13 @@ func resizeHorizontal(dst draw.Image, src image.Image, w int, resampling Resampl
 	pixSetter := newPixelSetter(dst)
 
 	parallelize(options.Parallelization, srcb.Min.Y, srcb.Max.Y, func(start, stop int) {
-		srcBuf := make([]pixel, srcb.Dx())
-		dstBuf := make([]pixel, w)
+		buf := getPixelBuf(srcb.Dx(), w)
+		defer putPixelBuf(buf)
+
 		for srcy := start; srcy < stop; srcy++ {
-			pixGetter.getPixelRow(srcy, &srcBuf)
-			resizeLine(dstBuf, srcBuf, weights)
-			pixSetter.setPixelRow(dstb.Min.Y+srcy-srcb.Min.Y, dstBuf)
+			pixGetter.getPixelRow(srcy, &buf.src)
+			resizeLine(buf.dst, buf.src, weights)
+			pixSetter.setPixelRow(dstb.Min.Y+srcy-srcb.Min.Y, buf.dst)
 		}
 	})
 }
@@ -167,12 +168,13 @@ func resizeVertical(dst draw.Image, src image.Image, h int, resampling Resamplin
 	pixSetter := newPixelSetter(dst)
 
 	parallelize(options.Parallelization, srcb.Min.X, srcb.Max.X, func(start, stop int) {
-		srcBuf := make([]pixel, srcb.Dy())
-		dstBuf := make([]pixel, h)
+		buf := getPixelBuf(srcb.Dy(), h)
+		defer putPixelBuf(buf)
+
 		for srcx := start; srcx < stop; srcx++ {
-			pixGetter.getPixelColumn(srcx, &srcBuf)
-			resizeLine(dstBuf, srcBuf, weights)
-			pixSetter.setPixelColumn(dstb.Min.X+srcx-srcb.Min.X, dstBuf)
+			pixGetter.getPixelColumn(srcx, &buf.src)
+			resizeLine(buf.dst, buf.src, weights)
+			pixSetter.setPixelColumn(dstb.Min.X+srcx-srcb.Min.X, buf.dst)
 		}
 	})
 }
@@ -276,7 +278,6 @@ func (p *resizeFilter) Draw(dst draw.Image, src image.Image, options *Options) {
 //	)
 //	dst := image.NewRGBA(g.Bounds(src.Bounds()))
 //	g.Draw(dst, src)
-//
 func Resize(width, height int, resampling Resampling) Filter {
 	return &resizeFilter{
 		width:      width,


### PR DESCRIPTION
```
cpu: Apple M1 Pro
                                 │ master.bench │           feat-perf.bench           │
                                 │    sec/op    │    sec/op     vs base               │
Filter/Resize_Lanczos-10            4.578m ± 1%   4.583m ±  2%        ~ (p=0.818 n=6)
Filter/Resize_Cubic-10              3.671m ± 0%   3.687m ±  1%        ~ (p=0.240 n=6)
Filter/Resize_Linear-10             2.934m ± 1%   3.005m ±  2%   +2.44% (p=0.004 n=6)
Filter/Resize_Box-10                2.665m ± 1%   2.758m ±  2%   +3.48% (p=0.002 n=6)
Filter/Resize_Nearest-10            79.28µ ± 0%   79.13µ ±  1%        ~ (p=0.240 n=6)
Filter/Crop-10                      101.1µ ± 0%   101.5µ ±  0%   +0.37% (p=0.002 n=6)
Filter/CropToSize-10                91.19µ ± 1%   91.96µ ±  1%   +0.85% (p=0.002 n=6)
Filter/FlipHorizontal-10            3.104m ± 1%   3.123m ±  0%        ~ (p=0.065 n=6)
Filter/FlipVertical-10              3.213m ± 1%   3.216m ±  0%        ~ (p=0.699 n=6)
Filter/Transpose-10                 3.202m ± 1%   3.202m ±  1%        ~ (p=0.818 n=6)
Filter/Transverse-10                3.294m ± 1%   3.283m ±  3%        ~ (p=0.240 n=6)
Filter/Rotate90-10                  3.117m ± 1%   3.109m ±  1%        ~ (p=0.310 n=6)
Filter/Rotate180-10                 3.096m ± 1%   3.096m ±  3%        ~ (p=0.818 n=6)
Filter/Rotate270-10                 3.215m ± 1%   3.205m ±  0%        ~ (p=0.240 n=6)
Filter/Rotate-10                    45.00m ± 3%   44.89m ±  2%        ~ (p=0.937 n=6)
Filter/Brightness-10                3.894m ± 1%   3.819m ±  1%   -1.93% (p=0.002 n=6)
Filter/Contrast-10                  4.415m ± 1%   4.417m ±  1%        ~ (p=0.937 n=6)
Filter/Saturation-10                5.698m ± 1%   5.680m ±  3%        ~ (p=0.310 n=6)
Filter/Gamma-10                     3.413m ± 0%   3.406m ±  0%        ~ (p=0.394 n=6)
Filter/GaussianBlur-10              14.06m ± 2%   14.03m ±  1%        ~ (p=0.485 n=6)
Filter/UnsharpMask-10               23.32m ± 1%   23.24m ±  2%        ~ (p=0.394 n=6)
Filter/Sigmoid-10                   3.457m ± 1%   3.453m ±  1%        ~ (p=0.818 n=6)
Filter/Pixelate-10                  3.516m ± 1%   3.504m ±  1%   -0.34% (p=0.041 n=6)
Filter/Colorize-10                  5.793m ± 1%   5.814m ±  1%        ~ (p=0.485 n=6)
Filter/ColorBalance-10              3.209m ± 2%   3.207m ±  0%        ~ (p=0.589 n=6)
Filter/Threshold-10                 3.334m ± 0%   3.343m ±  0%        ~ (p=0.093 n=6)
Filter/Hue-10                       6.423m ± 2%   6.423m ±  1%        ~ (p=0.699 n=6)
Filter/Grayscale-10                 3.176m ± 1%   3.178m ±  1%        ~ (p=0.818 n=6)
Filter/Sepia-10                     3.290m ± 1%   3.290m ±  4%        ~ (p=0.818 n=6)
Filter/Invert-10                    3.810m ± 0%   3.726m ±  1%   -2.21% (p=0.002 n=6)
Filter/ColorFunc-10                 3.339m ± 0%   3.345m ±  1%        ~ (p=0.589 n=6)
Filter/ColorspaceSRGBToLinear-10    3.421m ± 1%   3.422m ±  1%        ~ (p=0.699 n=6)
Filter/ColorspaceLinearToSRGB-10    3.424m ± 1%   3.422m ±  1%        ~ (p=0.394 n=6)
Filter/Mean-10                      9.886m ± 2%   9.745m ±  1%        ~ (p=0.065 n=6)
Filter/Median-10                    112.8m ± 1%   112.4m ±  4%        ~ (p=0.818 n=6)
Filter/Minimum-10                   37.59m ± 6%   43.18m ± 13%  +14.86% (p=0.002 n=6)
Filter/Maximum-10                   37.53m ± 2%   45.63m ±  7%  +21.60% (p=0.002 n=6)
Filter/Convolution-10               7.051m ± 1%   6.991m ±  1%   -0.85% (p=0.041 n=6)
Filter/Sobel-10                     22.40m ± 1%   22.56m ±  1%        ~ (p=0.394 n=6)
geomean                             4.239m        4.275m         +0.86%

                                 │ master.bench  │            feat-perf.bench            │
                                 │     B/op      │     B/op      vs base                 │
Filter/Resize_Lanczos-10            1.832Mi ± 0%   1.401Mi ± 0%  -23.52% (p=0.002 n=6)
Filter/Resize_Cubic-10              1.754Mi ± 0%   1.364Mi ± 0%  -22.22% (p=0.002 n=6)
Filter/Resize_Linear-10             1.692Mi ± 0%   1.295Mi ± 0%  -23.44% (p=0.002 n=6)
Filter/Resize_Box-10                1.647Mi ± 0%   1.260Mi ± 1%  -23.51% (p=0.002 n=6)
Filter/Resize_Nearest-10              896.0 ± 0%     896.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Crop-10                        880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/CropToSize-10                  880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/FlipHorizontal-10              880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/FlipVertical-10                880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Transpose-10                   880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Transverse-10                  880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate90-10                    880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate180-10                   880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate270-10                   880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate-10                      928.0 ± 0%     928.0 ± 0%        ~ (p=1.000 n=6)
Filter/Brightness-10                  912.0 ± 0%     912.0 ± 2%        ~ (p=1.000 n=6)
Filter/Contrast-10                    912.0 ± 0%     912.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Saturation-10                  880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Gamma-10                     1.891Ki ± 0%   1.891Ki ± 0%        ~ (p=1.000 n=6) ¹
Filter/GaussianBlur-10              12.17Mi ± 0%   11.51Mi ± 0%   -5.38% (p=0.002 n=6)
Filter/UnsharpMask-10               23.55Mi ± 0%   22.84Mi ± 0%   -3.02% (p=0.002 n=6)
Filter/Sigmoid-10                   1.891Ki ± 0%   1.891Ki ± 0%        ~ (p=1.000 n=6) ¹
Filter/Pixelate-10                    896.0 ± 0%     896.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Colorize-10                    880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorBalance-10                880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Threshold-10                   880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Hue-10                         880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6)
Filter/Grayscale-10                   880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Sepia-10                       880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Invert-10                      912.0 ± 0%     912.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorFunc-10                   880.0 ± 0%     880.0 ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorspaceSRGBToLinear-10    1.891Ki ± 0%   1.891Ki ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorspaceLinearToSRGB-10    1.891Ki ± 0%   1.891Ki ± 0%        ~ (p=1.000 n=6) ¹
Filter/Mean-10                      1.175Mi ± 0%   1.175Mi ± 0%        ~ (p=0.455 n=6)
Filter/Median-10                   13.672Ki ± 0%   5.562Ki ± 4%  -59.31% (p=0.002 n=6)
Filter/Minimum-10                  10.391Ki ± 0%   1.503Ki ± 3%  -85.54% (p=0.002 n=6)
Filter/Maximum-10                  10.391Ki ± 0%   1.470Ki ± 4%  -85.85% (p=0.002 n=6)
Filter/Convolution-10               722.0Ki ± 0%   722.0Ki ± 0%        ~ (p=0.987 n=6)
Filter/Sobel-10                     24.18Mi ± 0%   24.18Mi ± 0%        ~ (p=0.937 n=6)
geomean                             7.735Ki        6.644Ki       -14.10%
¹ all samples are equal

                                 │ master.bench │           feat-perf.bench           │
                                 │  allocs/op   │ allocs/op   vs base                 │
Filter/Resize_Lanczos-10             74.00 ± 0%   35.00 ± 3%  -52.70% (p=0.002 n=6)
Filter/Resize_Cubic-10               74.00 ± 0%   40.00 ± 3%  -45.95% (p=0.002 n=6)
Filter/Resize_Linear-10              74.00 ± 0%   39.00 ± 3%  -47.30% (p=0.002 n=6)
Filter/Resize_Box-10                 74.00 ± 0%   40.00 ± 3%  -45.95% (p=0.002 n=6)
Filter/Resize_Nearest-10             14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Crop-10                       14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/CropToSize-10                 14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/FlipHorizontal-10             14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/FlipVertical-10               14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Transpose-10                  14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Transverse-10                 14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate90-10                   14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate180-10                  14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate270-10                  14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Rotate-10                     14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Brightness-10                 14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Contrast-10                   14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Saturation-10                 14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Gamma-10                      15.00 ± 0%   15.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/GaussianBlur-10               78.00 ± 0%   47.50 ± 3%  -39.10% (p=0.002 n=6)
Filter/UnsharpMask-10                95.00 ± 0%   62.50 ± 6%  -34.21% (p=0.002 n=6)
Filter/Sigmoid-10                    15.00 ± 0%   15.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Pixelate-10                   14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Colorize-10                   14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorBalance-10               14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Threshold-10                  14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Hue-10                        14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Grayscale-10                  14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Sepia-10                      14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Invert-10                     14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorFunc-10                  14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorspaceSRGBToLinear-10     15.00 ± 0%   15.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/ColorspaceLinearToSRGB-10     15.00 ± 0%   15.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Mean-10                       81.00 ± 0%   81.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Median-10                     85.00 ± 0%   52.50 ± 3%  -38.24% (p=0.002 n=6)
Filter/Minimum-10                    55.00 ± 0%   18.00 ± 6%  -67.27% (p=0.002 n=6)
Filter/Maximum-10                    55.00 ± 0%   17.00 ± 6%  -69.09% (p=0.002 n=6)
Filter/Convolution-10                58.00 ± 0%   58.00 ± 0%        ~ (p=1.000 n=6) ¹
Filter/Sobel-10                      137.0 ± 0%   137.0 ± 0%        ~ (p=1.000 n=6) ¹
geomean                              23.72        20.18       -14.93%
```

There are some lines above that actually runs slower in this, e.g. `Filter/Maximum`, but:

* Running those benchmarks in isolation gets the diff down to ~7%.
* And the allocation saving should far outweigh this in real world usage.

I also added a .gitignore to avoid committing temporary files again.
